### PR TITLE
Fix Build Issues with ROS Noetic

### DIFF
--- a/indy7_moveit_config/launch/planning_context.launch
+++ b/indy7_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find indy7_description)/urdf/indy7_fixed.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find indy7_description)/urdf/indy7_fixed.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find indy7_moveit_config)/config/indy7.srdf" />

--- a/indy7_v2_description/CMakeLists.txt
+++ b/indy7_v2_description/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(indy7_description)
+project(indy7_v2_description)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)


### PR DESCRIPTION
- Remove `.py` from `xacro.py` to fix build with ros-noetic https://wiki.ros.org/noetic/Migration#Use_xacro_instead_of_xacro.py
- Fix `CMakeLists.txt`